### PR TITLE
feature: add swipeAction to trigger price update function

### DIFF
--- a/Barber_Application/Barber_Application/Objects.swift
+++ b/Barber_Application/Barber_Application/Objects.swift
@@ -554,4 +554,15 @@ class PendingArrayModel: ObservableObject {
     ]
 }
 
+// MARK: Swipe Trigger Functions (Temporary placeholder for backend call)
+
+// Placeholder function to simulate updating price
+func updatePriceLocally (_ newPrice: Int) {
+    print("Swipe action triggereed. Intended to update price to : \(newPrice)")
+    // TODO: Replace with API call to update price in DynamoDB
+}
+
+
+
+
 

--- a/Barber_Application/Barber_Application/Preview Content/Home.swift
+++ b/Barber_Application/Barber_Application/Preview Content/Home.swift
@@ -92,7 +92,7 @@ struct PriceChanger_Section: View {
             }
             .swipeActions(edge: .trailing){
                 Button{
-                    
+                    updatePriceLocally(price)
                 }label:{
                     Image(systemName: "dollarsign.arrow.circlepath")
                         .foregroundColor(.white)


### PR DESCRIPTION
### Summary
Implemented a swipeAction in the Barber Application that allows barbers to trigger a price update for clients.

### What I Did
- Added a swipeAction in `PriceChanger_Section` using SwiftUI's `.swipeActions`
- Used `dollarsign.arrow.circlepath` icon for clarity
- Created a placeholder function `updatePriceLocally(_:)` in `Objects.swift`
- This function logs the price and will later be connected to a backend API (via AWS API Gateway)

### Notes
- Currently the price is still stored locally
- Backend integration with DynamoDB will be handled in a future task

Let me know if any changes are needed!